### PR TITLE
Fix uci changeView() execute twice after login

### DIFF
--- a/luci2/htdocs/luci2/ui.js
+++ b/luci2/htdocs/luci2/ui.js
@@ -716,10 +716,10 @@
 			).then(function() {
 				self.renderView(L.globals.defaultNode).then(function() {
 					self.loading(false);
-				});
-
-				$(window).on('hashchange', function() {
-					self.changeView();
+					
+					$(window).on('hashchange', function() {
+						self.changeView();
+					});
 				});
 			});
 		},


### PR DESCRIPTION
when first login and load overview page, changeView execute twice, then all of the status is got twice in overview page.

fix: hook 'hashchange' event on window in overview renderView() callback function.
